### PR TITLE
Вывести теги технологий на карточках портфолио

### DIFF
--- a/_includes/portfolio-card.html
+++ b/_includes/portfolio-card.html
@@ -9,6 +9,13 @@
     </div>
     <div class="portfolio-card-body">
       <h3>{{ item.title | escape }}</h3>
+      {%- if item.technologies.size > 0 -%}
+        <div class="portfolio-card-tags">
+          {%- for tech in item.technologies -%}
+            <span class="tag">{{ tech }}</span>
+          {%- endfor -%}
+        </div>
+      {%- endif -%}
     </div>
   </a>
 </article>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1063,6 +1063,17 @@ body {
       line-height: 1.4;
       color: $foreground;
     }
+
+    .portfolio-card-tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.375rem;
+      margin-top: 0.5rem;
+
+      .tag {
+        font-size: 0.6875rem;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Display the list of technologies as small tag chips on each card of the `/portfolio/` listing, mirroring how tags are rendered on the case detail page.

- `_includes/portfolio-card.html`: добавлен блок `{% if item.technologies.size > 0 %}` под `<h3>` с циклом по `technologies` и `<span class="tag">`.
- `_sass/_custom.scss`: добавлен контейнер `.portfolio-card-tags` (flex / `flex-wrap: wrap` / `gap`) с уменьшенным размером `.tag` под карточный масштаб.
- Записи без `technologies` рендерятся без пустого контейнера; теги остаются `<span>`-ами, не перехватывая клик с родительской ссылки карточки.

## Open questions — resolved

- Показываем все теги без обрезки (детальная страница тоже показывает все).
- Используем тот же класс `.tag`, переопределяя только `font-size: 0.6875rem` в скоупе карточки.
- Теги располагаются отдельным блоком сразу после `<h3>` с `margin-top: 0.5rem`.

Closes #27